### PR TITLE
Fixed test problems with connections

### DIFF
--- a/src/test/java/DAO/shift/ShiftDAOTest.java
+++ b/src/test/java/DAO/shift/ShiftDAOTest.java
@@ -2,22 +2,18 @@ package DAO.shift;
 
 import db.IConnPool;
 import db.TestConnPoolV1;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.junit.*;
 
 public class ShiftDAOTest
 {
-	private IConnPool connPool;
+	private static IConnPool connPool;
 	
-	@Before
-	public void setUp() throws Exception
+	@BeforeClass
+	public static void setUp() throws Exception
 	{ connPool = TestConnPoolV1.getInstance(); }
 	
-	@After
-	public void tearDown() throws Exception
+	@AfterClass
+	public static void tearDown() throws Exception
 	{ connPool.closePool(); }
 	
 	@Test

--- a/src/test/java/DAO/workPlace/WorkPlaceDAOTest.java
+++ b/src/test/java/DAO/workPlace/WorkPlaceDAOTest.java
@@ -6,7 +6,7 @@ import DTOs.workPlace.WorkPlaceDTO;
 import db.DBController;
 import db.IConnPool;
 import db.TestConnPoolV1;
-import org.junit.Test;
+import org.junit.*;
 
 import java.awt.*;
 import java.util.List;
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class WorkPlaceDAOTest
 {
-    private IConnPool test_DB = TestConnPoolV1.getInstance();
+    private static IConnPool test_DB;
 
-    private DBController dbController = new DBController(test_DB);
+    private static DBController dbController;
 
-    private IWorkPlaceDAO iWorkPlaceDAO = dbController.getiWorkPlaceDAO();
+    private static IWorkPlaceDAO iWorkPlaceDAO;
 
     // region Test Material
 
@@ -67,7 +67,23 @@ public class WorkPlaceDAOTest
     }
 
     // endregion
-
+    
+    @BeforeClass
+    public static void setUp() throws Exception
+    {
+        test_DB = TestConnPoolV1.getInstance();
+    
+        dbController = new DBController(test_DB);
+    
+        iWorkPlaceDAO = dbController.getiWorkPlaceDAO();
+    }
+    
+    @AfterClass
+    public static void tearDown() throws Exception
+    {
+        test_DB.closePool();
+    }
+    
     /*
     ----------------------------- TESTS -----------------------------
      */

--- a/src/test/java/DAO/worker/WorkerDAOTest.java
+++ b/src/test/java/DAO/worker/WorkerDAOTest.java
@@ -8,11 +8,7 @@ import DTOs.worker.WorkerDTO;
 import db.DBController;
 import db.IConnPool;
 import db.TestConnPoolV1;
-import db.connectionPools.ConnPoolV1;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runners.MethodSorters;
 
 import java.time.LocalDate;
@@ -28,7 +24,7 @@ public class WorkerDAOTest
 	
 	//region Test Material
 	
-	private IConnPool connPool;
+	private static IConnPool connPool;
 	
 	private String firstName0 = "Bo"; String surName0 = "Børgesen";
 	private String email0 = String.format("%s.%s@hotmail.com", firstName0, surName0);
@@ -46,12 +42,12 @@ public class WorkerDAOTest
 	//endregion
 	
 	
-	@Before
-	public void setUp() throws Exception
+	@BeforeClass
+	public static void setUp() throws Exception
 	{ connPool = TestConnPoolV1.getInstance(); }
 	
-	@After
-	public void tearDown() throws Exception
+	@AfterClass
+	public static void tearDown() throws Exception
 	{ connPool.closePool(); }
 	
 	@Test

--- a/src/test/java/db/TestConnPoolV1.java
+++ b/src/test/java/db/TestConnPoolV1.java
@@ -13,7 +13,7 @@ public class TestConnPoolV1 extends ConnPoolV1 implements IConnPool
      * as it isn't possible to use superclass constructor otherwise.
      * @throws DALException Data Access Layer Exception
      */
-    protected TestConnPoolV1() throws DALException { super(); }
+    private TestConnPoolV1() throws DALException { super(); }
     
     /**
      * Gives the instance of the Test Connection Pool, which is using


### PR DESCRIPTION
Corrected test classes's use of the test connection pool, so that it only opens the pool, when the tests starts and only closes, when all the tests is done.